### PR TITLE
first implementation of the serialization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost COMPONENTS serialization)
+
 rock_library(envire_core
     HEADERS items/ItemBase.hpp
             items/Item.hpp
@@ -23,7 +25,11 @@ rock_library(envire_core
             events/TransformModifiedEvent.hpp
             events/TransformRemovedEvent.hpp
             events/ItemAddedEvent.hpp
-
+            serialization/Serialization.hpp
+            serialization/SerializationHandle.hpp
+            serialization/SerializationRegistration.hpp
+            serialization/ItemHeader.hpp
+            serialization/Eigen.hpp
     SOURCES items/ItemBase.cpp
             items/BoundingVolume.cpp
             items/AlignedBoundingBox.cpp
@@ -31,7 +37,8 @@ rock_library(envire_core
             plugin/ClassLoader.cpp
             events/GraphEventPublisher.cpp
             events/GraphEventDispatcher.cpp
-            graph/TransformGraph.cpp            
+            graph/TransformGraph.cpp
+            serialization/Serialization.cpp
     DEPS_CMAKE Boost
     DEPS_PKGCONFIG base-types class_loader)
 
@@ -39,4 +46,3 @@ rock_library(envire_core
 install(FILES
     all
     DESTINATION include/envire_core)
-

--- a/src/items/DummyItem.hpp
+++ b/src/items/DummyItem.hpp
@@ -45,6 +45,8 @@
 //#include "WorldPhysics.h"
 //#include "envire_core/TransformTree.hpp"
 #include "Item.hpp"
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/vector.hpp>
 
 using namespace envire::core;
 
@@ -61,6 +63,15 @@ namespace envire{
         void welcome();
         int getId();
         std::vector<double> getMyVector();
+
+    private:
+        friend class boost::serialization::access;
+        template <typename Archive>
+        void serialize(Archive &ar, const unsigned int version)
+        {
+            ar & BOOST_SERIALIZATION_NVP(id);
+            ar & BOOST_SERIALIZATION_NVP(myVector);
+        }
     };
     // Inheritance from a template fitting the DummyClass type
     class DummyItem : public Item<DummyClass> {

--- a/src/items/Item.hpp
+++ b/src/items/Item.hpp
@@ -66,6 +66,9 @@ namespace envire { namespace core
     template<class _ItemData>
     class Item : public ItemBase
     {
+    public:
+        typedef boost::shared_ptr< Item<_ItemData> > Ptr;
+
     protected:
 
         _ItemData user_data;

--- a/src/items/Item.hpp
+++ b/src/items/Item.hpp
@@ -3,7 +3,8 @@
 
 #include "ItemBase.hpp"
 #include <class_loader/class_loader.h>
-#include <utility>                                                              
+#include <utility>
+#include <envire_core/serialization/SerializationRegistration.hpp>
 
 /**
  * ** Envire marcos **
@@ -16,29 +17,32 @@
  * Example usage in *.hpp:
  *      class VectorPlugin : public Item<Eigen::Vector3d>
  *      {
- *          ENVIRE_PLUGIN_HEADER(VectorPlugin)
+ *          ENVIRE_PLUGIN_HEADER(VectorPlugin, Eigen::Vector3d)
  *
  *          [...]
  *      }
  */
-#define ENVIRE_PLUGIN_HEADER( _classname ) \
+#define ENVIRE_PLUGIN_HEADER( _classname, _datatype ) \
     protected: \
     static const std::string class_name; \
     public:\
     const std::string& getClassName() const { return class_name; } \
-    typedef boost::intrusive_ptr<_classname> Ptr; \
-    private:
+    typedef boost::shared_ptr<_classname> Ptr; \
+    private: \
+    ENVIRE_SERIALIZATION_HEADER(_datatype)
 
 /**
  * The ENVIRE_REGISTER_PLUGIN macro exports the given class as plugin.
  * The class must be inherited from envire::core::ItemBase.
  *
  * Example usage in *.cpp:
- *      ENVIRE_REGISTER_PLUGIN(ClassName)
+ *      ENVIRE_REGISTER_PLUGIN(ClassName, DataType)
  */
-#define ENVIRE_REGISTER_PLUGIN( _classname ) \
+#define ENVIRE_REGISTER_PLUGIN( _classname, _datatype ) \
 const std::string _classname::class_name = #_classname; \
-CLASS_LOADER_REGISTER_CLASS(_classname, envire::core::ItemBase);
+CLASS_LOADER_REGISTER_CLASS(_classname, envire::core::ItemBase); \
+ENVIRE_REGISTER_SERIALIZATION(_classname, _datatype)
+
 
 /**
  * The ENVIRE_PLUGIN macro defines the complete plugin class.
@@ -51,9 +55,9 @@ CLASS_LOADER_REGISTER_CLASS(_classname, envire::core::ItemBase);
 #define ENVIRE_PLUGIN( _classname, _datatype ) \
 class _classname : public envire::core::Item<_datatype> \
 { \
-    ENVIRE_PLUGIN_HEADER(_classname) \
+    ENVIRE_PLUGIN_HEADER( _classname, _datatype ) \
 }; \
-ENVIRE_REGISTER_PLUGIN( _classname )
+ENVIRE_REGISTER_PLUGIN( _classname, _datatype )
 
 
 namespace envire { namespace core
@@ -99,6 +103,16 @@ namespace envire { namespace core
         *
         */
         _ItemData& getData() { return this->user_data; }
+
+    private:
+        friend class boost::serialization::access;
+
+        template <typename Archive>
+        void serialize(Archive &ar, const unsigned int version)
+        {
+            ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(envire::core::ItemBase);
+            ar & BOOST_SERIALIZATION_NVP(user_data);
+        }
 
     };
 

--- a/src/items/ItemBase.cpp
+++ b/src/items/ItemBase.cpp
@@ -5,9 +5,6 @@ using namespace envire::core;
 
 const std::string ItemBase::class_name = "envire::core::ItemBase";
 
-void envire::core::intrusive_ptr_add_ref( ItemBase* item ) { item->ref_count++; }
-void envire::core::intrusive_ptr_release( ItemBase* item ) { if(!--item->ref_count) delete item; }
-
-ItemBase::ItemBase() : ref_count(0), time(base::Time::now()), uuid(RandomGenerator::getRandomGenerator()()), user_data_ptr(NULL)
+ItemBase::ItemBase() : time(base::Time::now()), uuid(RandomGenerator::getRandomGenerator()()), user_data_ptr(NULL)
 {
 }

--- a/src/items/ItemBase.hpp
+++ b/src/items/ItemBase.hpp
@@ -4,12 +4,16 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/binary_object.hpp>
 #include <base/Time.hpp>
 #include <string>
 
 namespace envire { namespace core
 {
-
     /**@class ItemBase
     *
     * ItemBase class
@@ -87,12 +91,24 @@ namespace envire { namespace core
         */
         virtual const std::string& getClassName() const { return class_name; }
 
+        void* getRawData() const { return user_data_ptr; }
 
+    private:
+        friend class boost::serialization::access;
 
+        template <typename Archive>
+        void serialize(Archive &ar, const unsigned int version)
+        {
+            ar & boost::serialization::make_nvp("time", time.microseconds);
+            ar & boost::serialization::make_nvp("uuid", boost::serialization::make_binary_object(uuid.data, uuid.size()));
+            ar & BOOST_SERIALIZATION_NVP(frame_name);
+        }
     };
 
+    BOOST_SERIALIZATION_ASSUME_ABSTRACT(envire::core::ItemBase)
 
 }}
+
 #endif
 
 

--- a/src/items/ItemBase.hpp
+++ b/src/items/ItemBase.hpp
@@ -3,7 +3,7 @@
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/intrusive_ptr.hpp>
+#include <boost/shared_ptr.hpp>
 #include <base/Time.hpp>
 #include <string>
 
@@ -17,14 +17,9 @@ namespace envire { namespace core
     class ItemBase
     {
     public:
-
-        typedef boost::intrusive_ptr<ItemBase> Ptr;
+        typedef boost::shared_ptr<ItemBase> Ptr;
 
     protected:
-
-        /* TBD: using the intrusive pointer the raw pointer and the intrusive_ptr have the same memory layout.
-         * But in the serialization the ref count must be tropped */
-        long ref_count; /** Reference counter of the smart pointer */
 
         base::Time time; /** Timestamp */
 
@@ -92,22 +87,10 @@ namespace envire { namespace core
         */
         virtual const std::string& getClassName() const { return class_name; }
 
-        /**@brief getRefCount
-        *
-        * Returns the reference count of the item
-        *
-        */
-        long getRefCount() const { return ref_count; }
 
-    protected:
-
-        friend void intrusive_ptr_add_ref( ItemBase* item );
-        friend void intrusive_ptr_release( ItemBase* item );
 
     };
 
-    void intrusive_ptr_add_ref( ItemBase* item );
-    void intrusive_ptr_release( ItemBase* item );
 
 }}
 #endif

--- a/src/plugin/ClassLoader.cpp
+++ b/src/plugin/ClassLoader.cpp
@@ -63,11 +63,11 @@ bool ClassLoader::hasItem(const std::string& class_name)
 
 ClassLoader::ItemBaseClassPtr ClassLoader::createItem(const std::string& class_name)
 {
-    return ItemBaseClassPtr(createItemIntern(class_name));
+    return createItemIntern(class_name);
 }
 
 
-ClassLoader::ItemBaseClass* ClassLoader::createItemIntern(const std::string& class_name)
+ClassLoader::ItemBaseClassPtr ClassLoader::createItemIntern(const std::string& class_name)
 {
     LoaderMap::iterator it = loaders.find(class_name);
 
@@ -84,7 +84,7 @@ ClassLoader::ItemBaseClass* ClassLoader::createItemIntern(const std::string& cla
         throw std::runtime_error(error_msg);
     }
     else
-        return it->second->createUnmanagedInstance<ItemBaseClass>(class_name);
+        return it->second->createInstance<ItemBaseClass>(class_name);
 }
 
 void ClassLoader::loadLibrary(const std::string& class_name)

--- a/src/plugin/ClassLoader.hpp
+++ b/src/plugin/ClassLoader.hpp
@@ -36,15 +36,15 @@ namespace envire
         template<class T>
         typename T::Ptr createItem(const std::string& class_name)
         {
-            ItemBaseClass* item = createItemIntern(class_name);
-            T* inherited_item = dynamic_cast<T*>(item);
+            ItemBaseClassPtr item = createItemIntern(class_name);
+            typename T::Ptr inherited_item = boost::dynamic_pointer_cast<T>(item);
             if(inherited_item == NULL)
             {
                 std::string error_msg = "Failed to cast item of type ";
                 error_msg += class_name;
                 throw std::runtime_error(error_msg);
             }
-            return typename T::Ptr(inherited_item);
+            return inherited_item;
         }
         
         /**Loads LD_LIBRARY_PATH and parses it into a list of paths */
@@ -63,7 +63,7 @@ namespace envire
 
     private:
 
-        ItemBaseClass* createItemIntern(const std::string& class_name);
+        ItemBaseClassPtr createItemIntern(const std::string& class_name);
 
         void loadLibrary(const std::string& class_name);
 

--- a/src/serialization/Eigen.hpp
+++ b/src/serialization/Eigen.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <boost/serialization/array.hpp>
+#include <Eigen/Core>
+
+namespace boost { namespace serialization
+{
+
+    template<typename _Archive, typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+    inline void serialize(
+        _Archive & ar,
+        Eigen::Matrix< _Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols >& matrix,
+        const unsigned int version)
+    {
+        int rows = matrix.rows();
+        int cols = matrix.cols();
+        ar & rows;
+        ar & cols;
+        if(rows != matrix.rows() || cols != matrix.cols())
+            matrix.resize(rows, cols);
+        ar & boost::serialization::make_array(matrix.data(), rows * cols);
+    }
+
+}}

--- a/src/serialization/ItemHeader.hpp
+++ b/src/serialization/ItemHeader.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <envire_core/items/ItemBase.hpp>
+
+namespace envire { namespace core
+{
+
+class ItemHeader
+{
+public:
+    ItemHeader() {}
+    ItemHeader(const std::string& class_name) {this->class_name = class_name;}
+    ItemHeader(const ItemBase::Ptr& item) {this->class_name = item->getClassName();}
+
+    std::string class_name;
+    // TODO extend by data size
+
+private:
+    friend class boost::serialization::access;
+
+    template <typename Archive>
+    void serialize(Archive &ar, const unsigned int version)
+    {
+        ar & BOOST_SERIALIZATION_NVP(class_name);
+    }
+};
+
+}}

--- a/src/serialization/Serialization.cpp
+++ b/src/serialization/Serialization.cpp
@@ -1,0 +1,86 @@
+#include "Serialization.hpp"
+
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/nvp.hpp>
+
+using namespace envire::core;
+
+bool Serialization::save(ArchiveOutType& ar, const ItemBase::Ptr& item)
+{
+    try
+    {
+        if(!hasHandle(item->getClassName()))
+        {
+            std::cerr << "Cannot find plugin " << item->getClassName() << std::endl;
+            throw std::runtime_error("Automatic lookup of plugins is not implemented yet.");
+            //TODO try to load library if handle is not available
+        }
+        HandlePtr handle;
+        if(getHandle(item->getClassName(), handle) && handle)
+        {
+            ItemHeader header(item);
+            ar << BOOST_SERIALIZATION_NVP(header);
+            return handle->save(ar, item);
+        }
+        return false;
+    }
+    catch(const std::runtime_error& e)
+    {
+        return false;
+    }
+    return false;
+};
+
+bool Serialization::load(ArchiveInType& ar, ItemBase::Ptr& item)
+{
+    try
+    {
+        ItemHeader header;
+        ar >> BOOST_SERIALIZATION_NVP(header);
+        if(!hasHandle(header.class_name))
+        {
+            std::cerr << "Cannot find plugin " << header.class_name << std::endl;
+            throw std::runtime_error("Automatic lookup of plugins is not implemented yet.");
+            //TODO try to load library if handle is not available
+        }
+        HandlePtr handle;
+        if(getHandle(header.class_name, handle) && handle)
+            return handle->load(ar, item);
+        return false;
+    }
+    catch(const std::runtime_error& e)
+    {
+        return false;
+    }
+    return false;
+};
+
+Serialization::HandleMap& Serialization::getHandleMap()
+{
+    static HandleMap handle_map;
+    return handle_map;
+}
+
+void Serialization::registerHandle(const std::string& plugin_name, Serialization::HandlePtr& handle)
+{
+    HandleMap& handle_map = getHandleMap();
+    handle_map[plugin_name] = handle;
+}
+
+bool Serialization::hasHandle(const std::string& plugin_name)
+{
+    HandleMap& handle_map = getHandleMap();
+    return handle_map.find(plugin_name) != handle_map.end();
+}
+
+bool Serialization::getHandle(const std::string& plugin_name, Serialization::HandlePtr& handle)
+{
+    HandleMap& handle_map = getHandleMap();
+    HandleMap::iterator it = handle_map.find(plugin_name);
+    if(it != handle_map.end())
+    {
+        handle = it->second;
+        return true;
+    }
+    return false;
+}

--- a/src/serialization/Serialization.hpp
+++ b/src/serialization/Serialization.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "SerializationHandle.hpp"
+#include "ItemHeader.hpp"
+#include <envire_core/items/ItemBase.hpp>
+
+#include <map>
+
+namespace envire { namespace core
+{
+
+class Serialization
+{
+    typedef boost::shared_ptr<SerializationHandle> HandlePtr;
+    typedef std::map< std::string, HandlePtr > HandleMap;
+
+public:
+
+    static bool save(ArchiveOutType& ar, const ItemBase::Ptr& item);
+
+    static bool load(ArchiveInType& ar, ItemBase::Ptr& item);
+
+    template<typename T>
+    static bool load(ArchiveInType& in, typename T::Ptr& item)
+    {
+        ItemBase::Ptr base_item;
+        bool result = load(in, base_item);
+        item = boost::dynamic_pointer_cast<T>(base_item);
+        return result;
+    }
+
+    static HandleMap& getHandleMap();
+
+    static void registerHandle(const std::string& plugin_name, HandlePtr& handle);
+
+    static bool hasHandle(const std::string& plugin_name);
+
+    static bool getHandle(const std::string& plugin_name, HandlePtr& handle);
+};
+
+}}

--- a/src/serialization/SerializationHandle.hpp
+++ b/src/serialization/SerializationHandle.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <envire_core/items/ItemBase.hpp>
+
+#include <boost/archive/polymorphic_iarchive.hpp>
+#include <boost/archive/polymorphic_oarchive.hpp>
+
+namespace envire { namespace core
+{
+
+typedef boost::archive::polymorphic_iarchive ArchiveInType;
+typedef boost::archive::polymorphic_oarchive ArchiveOutType;
+
+class SerializationHandle
+{
+public:
+    virtual ~SerializationHandle() {}
+
+    virtual bool save(ArchiveOutType& ar, const ItemBase::Ptr& item)
+    {
+        throw std::runtime_error("Method save is not implemented!");
+    };
+
+    virtual bool load(ArchiveInType& ar, ItemBase::Ptr& item)
+    {
+        throw std::runtime_error("Method load is not implemented!");
+    };
+};
+
+}}

--- a/src/serialization/SerializationRegistration.hpp
+++ b/src/serialization/SerializationRegistration.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "SerializationHandle.hpp"
+#include "Serialization.hpp"
+#include "Eigen.hpp"
+#include <envire_core/items/ItemBase.hpp>
+
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/export.hpp>
+
+namespace envire { namespace core
+{
+
+#define ENVIRE_SERIALIZATION_HEADER( _datatype ) \
+friend class boost::serialization::access; \
+template <typename Archive> \
+void serialize(Archive &ar, const unsigned int version) \
+{ \
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(envire::core::Item<_datatype>); \
+}
+
+#define ENVIRE_REGISTER_SERIALIZATION( _classname, _datatype ) \
+BOOST_CLASS_EXPORT(envire::core::ItemBase) \
+BOOST_CLASS_EXPORT(envire::core::Item< _datatype >) \
+BOOST_CLASS_EXPORT(_classname) \
+class _classname ## SerializationHandle : public envire::core::SerializationHandle \
+{ \
+private: \
+    virtual bool save(envire::core::ArchiveOutType& ar, const envire::core::ItemBase::Ptr& item) \
+    { \
+        ar << BOOST_SERIALIZATION_NVP(item); \
+        return true; \
+    }; \
+    virtual bool load(envire::core::ArchiveInType& ar, envire::core::ItemBase::Ptr& item) \
+    { \
+        ar >> BOOST_SERIALIZATION_NVP(item); \
+        return true; \
+    }; \
+}; \
+static envire::core::SerializationRegistration<_classname ## SerializationHandle> reg(#_classname);
+
+template<typename T>
+class SerializationRegistration
+{
+public:
+    SerializationRegistration(const std::string& class_name)
+    {
+        boost::shared_ptr<SerializationHandle> ptr(new T);
+        Serialization::registerHandle(class_name, ptr);
+    }
+};
+
+}}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(Boost COMPONENTS unit_test_framework system filesystem serialization)
+
 rock_library(VectorPlugin_envire_plugin
     SOURCES vector_plugin.cpp
     DEPS envire_core
@@ -9,6 +11,7 @@ rock_testsuite(test_suite suite.cpp
     test_transform_graph.cpp
     test_boundary.cpp
     test_frame.cpp
+    test_serialization.cpp
     DEPS_CMAKE Boost
     DEPS envire_core
     DEPS_PKGCONFIG class_loader)
@@ -17,8 +20,6 @@ rock_testsuite(test_dummy suite.cpp
     test_dummy_graph.cpp
     test_property_tag.cpp)
 
-find_package(Boost COMPONENTS unit_test_framework system filesystem)
-target_link_libraries(test_suite ${Boost_LIBRARIES})
 rock_testsuite(test_parameter_forwarding suite.cpp
     test_dummy_item.cpp
     DEPS_CMAKE Boost

--- a/test/test_plugins.cpp
+++ b/test/test_plugins.cpp
@@ -58,9 +58,9 @@ BOOST_AUTO_TEST_CASE(class_loader_test)
     ItemBase::Ptr vector_plugin = envire::ClassLoader::getInstance()->createItem("VectorPlugin");
     BOOST_ASSERT(envire::ClassLoader::getInstance()->hasItem("VectorPlugin"));
     BOOST_ASSERT(vector_plugin->getClassName() == "VectorPlugin");
-    BOOST_ASSERT(vector_plugin->getRefCount() == 1);
+    BOOST_ASSERT(vector_plugin.use_count() == 1);
     ItemBase::Ptr vector_plugin_2 = vector_plugin;
-    BOOST_ASSERT(vector_plugin->getRefCount() == 2);
+    BOOST_ASSERT(vector_plugin.use_count() == 2);
     BOOST_ASSERT(vector_plugin->getID() == vector_plugin_2->getID());
 
     Item<Eigen::Vector3d>::Ptr vector_plugin_3 = envire::ClassLoader::getInstance()->createItem< Item<Eigen::Vector3d> >("VectorPlugin");

--- a/test/test_serialization.cpp
+++ b/test/test_serialization.cpp
@@ -1,0 +1,86 @@
+#include <boost/test/unit_test.hpp>
+
+#include <Eigen/Geometry>
+#include <boost/serialization/shared_ptr.hpp>
+#include <boost/archive/polymorphic_text_iarchive.hpp>
+#include <boost/archive/polymorphic_text_oarchive.hpp>
+#include <boost/archive/polymorphic_binary_iarchive.hpp>
+#include <boost/archive/polymorphic_binary_oarchive.hpp>
+
+#include <envire_core/serialization/Serialization.hpp>
+#include <envire_core/items/Item.hpp>
+#include <envire_core/plugin/ClassLoader.hpp>
+
+using namespace envire::core;
+
+BOOST_AUTO_TEST_CASE(vector_plugin_serialization_text)
+{
+    BOOST_CHECK(envire::ClassLoader::getInstance()->hasValidPluginPath());
+
+    // create vector plugin
+    auto base_plugin = envire::ClassLoader::getInstance()->createItem("VectorPlugin");
+    BOOST_CHECK(base_plugin != NULL);
+    Item<Eigen::Vector3d>::Ptr vector_plugin;
+    vector_plugin = boost::dynamic_pointer_cast< Item<Eigen::Vector3d> >(base_plugin);
+    BOOST_CHECK(vector_plugin != NULL);
+
+    // set values
+    vector_plugin->setFrame("body");
+    vector_plugin->setTime(base::Time::now());
+    vector_plugin->getData().x() = 2.0;
+    vector_plugin->getData().y() = 3.0;
+    vector_plugin->getData().z() = -5.0;
+
+    // serialize to string stream
+    std::stringstream stream;
+    boost::archive::polymorphic_text_oarchive oa(stream);
+    BOOST_CHECK(Serialization::save(oa, base_plugin));
+
+    // deserialize from string stream
+    boost::archive::polymorphic_text_iarchive ia(stream);
+    envire::core::ItemBase::Ptr base_plugin_2 = NULL;
+    BOOST_CHECK(Serialization::load(ia, base_plugin_2));
+
+    // check if internal state is identical
+    Item<Eigen::Vector3d>::Ptr vector_plugin_2 = boost::dynamic_pointer_cast< Item<Eigen::Vector3d> >(base_plugin_2);
+    BOOST_CHECK(vector_plugin_2->getFrame() == vector_plugin->getFrame());
+    BOOST_CHECK(vector_plugin_2->getData() == vector_plugin->getData());
+    BOOST_CHECK(vector_plugin_2->getID() == vector_plugin->getID());
+    BOOST_CHECK(vector_plugin_2->getTime() == vector_plugin->getTime());
+}
+
+BOOST_AUTO_TEST_CASE(vector_plugin_serialization_binary)
+{
+    BOOST_CHECK(envire::ClassLoader::getInstance()->hasValidPluginPath());
+
+    // create vector plugin
+    auto base_plugin = envire::ClassLoader::getInstance()->createItem("VectorPlugin");
+    BOOST_CHECK(base_plugin != NULL);
+    Item<Eigen::Vector3d>::Ptr vector_plugin;
+    vector_plugin = boost::dynamic_pointer_cast< Item<Eigen::Vector3d> >(base_plugin);
+    BOOST_CHECK(vector_plugin != NULL);
+
+    // set values
+    vector_plugin->setFrame("body");
+    vector_plugin->setTime(base::Time::now());
+    vector_plugin->getData().x() = 2.0;
+    vector_plugin->getData().y() = 3.0;
+    vector_plugin->getData().z() = -5.0;
+
+    // serialize to string stream
+    std::stringstream stream;
+    boost::archive::polymorphic_binary_oarchive oa(stream);
+    BOOST_CHECK(Serialization::save(oa, base_plugin));
+
+    // deserialize from string stream
+    boost::archive::polymorphic_binary_iarchive ia(stream);
+    envire::core::ItemBase::Ptr base_plugin_2 = NULL;
+    BOOST_CHECK(Serialization::load(ia, base_plugin_2));
+
+    // check if internal state is identical
+    Item<Eigen::Vector3d>::Ptr vector_plugin_2 = boost::dynamic_pointer_cast< Item<Eigen::Vector3d> >(base_plugin_2);
+    BOOST_CHECK(vector_plugin_2->getFrame() == vector_plugin->getFrame());
+    BOOST_CHECK(vector_plugin_2->getData() == vector_plugin->getData());
+    BOOST_CHECK(vector_plugin_2->getID() == vector_plugin->getID());
+    BOOST_CHECK(vector_plugin_2->getTime() == vector_plugin->getTime());
+}

--- a/test/vector_plugin.cpp
+++ b/test/vector_plugin.cpp
@@ -1,7 +1,6 @@
 #include <envire_core/items/Item.hpp>
 #include <Eigen/Geometry>
 
-namespace envire
-{
-    ENVIRE_PLUGIN(VectorPlugin, Eigen::Vector3d)
-}
+using namespace envire;
+
+ENVIRE_PLUGIN( VectorPlugin, Eigen::Vector3d )


### PR DESCRIPTION
This is the first implementation of the serialization based on boost.

It involves to switch from intrusive to shared pointers as default smart pointer. The background is that shared pointers are directly supported by boost serialization. And as far as I know it would also be more compatible to mars right?

There are two new macros which allows the BaseItem to be automatically serialized. Those are currently part of the existing macros, which might force the user to implement a serialize method for the data type that is used in the Item. We could also make this optional.
The existing macros to define a new envire Item where extended by a data type parameter.

I'll extend the implementation by documentation and more unit tests in the next days.

Also the automatic lookup of the plugin in case it was not loaded yet is missing.