### PR TITLE
TransformGraph: getTree() returns a list of cross-edges as well

### DIFF
--- a/src/graph/TransformGraph.cpp
+++ b/src/graph/TransformGraph.cpp
@@ -318,12 +318,12 @@ const envire::core::FrameId& TransformGraph::getFrameId(const vertex_descriptor 
 }
 
 
-VertexRelationMap TransformGraph::getTree(const vertex_descriptor root) const
+TreeView TransformGraph::getTree(const vertex_descriptor root) const
 {
-    VertexRelationMap map;
-    TreeBuilderVisitor visitor(map);
+    TreeView view;
+    TreeBuilderVisitor visitor(view);
     boost::breadth_first_search(*this, root, boost::visitor(visitor));
-    return map;
+    return view;
 }
 
 vector<FrameId> TransformGraph::getPath(FrameId origin, FrameId target)
@@ -353,7 +353,7 @@ vector<FrameId> TransformGraph::getPath(FrameId origin, FrameId target)
 }
 
 
-VertexRelationMap TransformGraph::getTree(const FrameId rootId) const
+TreeView TransformGraph::getTree(const FrameId rootId) const
 {
     const vertex_descriptor root = getVertex(rootId);
     return getTree(root);
@@ -384,4 +384,12 @@ vertex_descriptor TransformGraph::getVertex(const FrameId& frame) const
     return desc;
 }
 
+const vertex_descriptor TransformGraph::source(const edge_descriptor edge) const
+{
+    return boost::source(edge, graph());
+}
+const vertex_descriptor TransformGraph::target(const edge_descriptor edge) const
+{
+    return boost::target(edge, graph());
+}
 

--- a/src/graph/TransformGraph.hpp
+++ b/src/graph/TransformGraph.hpp
@@ -166,11 +166,11 @@ namespace envire { namespace core
         
         /**Builds a tree containing all vertices that are accessible starting
          * from @p root.  */
-        VertexRelationMap getTree(const vertex_descriptor root) const;
+        TreeView getTree(const vertex_descriptor root) const;
         /**Builds a tree containing all vertices that are accessible starting
          * from @p root.
          * @throw UnknownFrameException if the frame does not exist */
-        VertexRelationMap getTree(const FrameId rootId) const;
+        TreeView getTree(const FrameId rootId) const;
         
         /**Returns the shortest path from @p origin to @p target.
          * Returns an empty vector if the path doesn't exist.
@@ -222,6 +222,9 @@ namespace envire { namespace core
         size_t getItemCount(const FrameId& frame) const;
         template <class T>
         size_t getItemCount(const vertex_descriptor vd) const;        
+        
+        const vertex_descriptor source(const edge_descriptor edge) const;
+        const vertex_descriptor target(const edge_descriptor edge) const;
         
     protected:
         using EdgePair = std::pair<edge_descriptor, bool>;

--- a/src/graph/TransformGraphTypes.hpp
+++ b/src/graph/TransformGraphTypes.hpp
@@ -74,10 +74,20 @@ namespace envire { namespace core
         vertex_descriptor parent;
         std::unordered_set<vertex_descriptor> children;
     };
-
+    
     /**A map that shows the vertex information (parent and children) of the vertices in a tree.
        The key is the vertex descriptor.*/
     using VertexRelationMap = std::unordered_map<vertex_descriptor, VertexRelation>;
+    
+    struct TreeView
+    {
+      VertexRelationMap tree;
+      /*The edges, that had to be removed to create the tree.
+       *I.e. All edges that lead to a vertex that has already been discovered.
+       *This does **not** include back-edges. I.e. edges that lead to a vertex that
+       *has already been visited. */
+      std::vector<edge_descriptor> crossEdges; 
+    };
 
 }}
 #endif /* SRC_TRANSFORMTREETYPES_HPP_ */

--- a/src/graph/TransformGraphVisitors.hpp
+++ b/src/graph/TransformGraphVisitors.hpp
@@ -75,8 +75,10 @@ namespace envire { namespace core
     /**Visits every node in bfs order and stores the search tree in the provided map */
     struct TreeBuilderVisitor : public boost::default_bfs_visitor
     {
-        TreeBuilderVisitor(VertexRelationMap& tree) : tree(tree) {}
+        TreeBuilderVisitor(TreeView& view) : view(view) {}
 
+        /**This is invoked on each edge as it becomes a member of 
+         * the edges that form the search tree. */
         template <typename Edge, typename Graph>
         void tree_edge(Edge e, const Graph &g)
         {
@@ -84,12 +86,23 @@ namespace envire { namespace core
             vertex_descriptor target = boost::target(e,g);
 
             /** Insert children **/
-            tree[source].children.insert(target);
+            view.tree[source].children.insert(target);
 
             /** Insert parent **/
-            tree[target].parent = source;
+            view.tree[target].parent = source;
         }
-        VertexRelationMap& tree;
+        
+        /**This is only invoked on cross edges, not on back edges
+         * @see http://www.boost.org/doc/libs/1_59_0/libs/graph/doc/BFSVisitor.html
+         * @see http://www.boost.org/doc/libs/1_59_0/libs/graph/doc/breadth_first_search.html
+         */
+        template <typename Edge, typename Graph>
+        void gray_target(Edge e, Graph& g)
+        {
+            view.crossEdges.push_back(e);
+        }
+        
+        TreeView& view;
     };
 
 


### PR DESCRIPTION
cross-edges are the edges that have been removed to construct the tree.
This information can be used to avoid creating invalid trees when updating transforms based on the tree.